### PR TITLE
Use new events API and handle missing world boss

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const API_URL = 'https://d4armory.io/api/events/upcoming/worldboss';
+const API_URL = 'https://d4armory.io/api/events.json';
 
 // Přibližné souřadnice světových bossů v systému lat/lon
 const BOSS_LOCATIONS = {
@@ -17,12 +17,23 @@ async function loadBoss() {
     const res = await fetch(API_URL);
     const data = await res.json();
 
-    const bossName = data.boss || data.worldBoss;
-    const location = data.territory || data.zone || data.location;
-    const expected = data.expected || data.spawn; // timestamp v ms
+    const worldBoss = Array.isArray(data)
+      ? data.find(ev => ev.e === 'World Boss')
+      : null;
+
+    if (!worldBoss) {
+      document.getElementById('boss').textContent =
+        'Žádný World Boss nebyl nalezen.';
+      return;
+    }
+
+    const bossName = worldBoss.n;
+    const location = worldBoss.t || worldBoss.z;
+    const expected = worldBoss.ts; // timestamp v s
 
     document.getElementById('boss').textContent = `Další boss: ${bossName}`;
-    document.getElementById('location').textContent = `Místo: ${location}`;
+    document.getElementById('location').textContent =
+      location ? `Místo: ${location}` : '';
 
     if (expected) {
       startCountdown(expected);
@@ -35,8 +46,8 @@ async function loadBoss() {
   }
 }
 
-function startCountdown(targetTime) {
-  const target = typeof targetTime === 'number' && targetTime < 1e12 ? targetTime * 1000 : targetTime;
+function startCountdown(targetTimeSec) {
+  const target = targetTimeSec * 1000;
 
   function update() {
     const diff = target - Date.now();


### PR DESCRIPTION
## Summary
- Switch to the `/api/events.json` endpoint
- Filter "World Boss" event and extract name, location and timestamp
- Convert timestamps from seconds and show message when no boss is scheduled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968ca60114832386d8cde567ed810a